### PR TITLE
Update CMakeLists.txt for python to fix installation path

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,14 +11,14 @@ set(PYTHON_PACKAGES
 # Install the __init__.py files and modules for each sub-package
 foreach(PACKAGE ${PYTHON_PACKAGES})
     install(FILES ${PACKAGE}/__init__.py
-            DESTINATION ${Python3_SITELIB}/${PROJECT_NAME}/${PACKAGE})
+            DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/${PACKAGE})
     
     file(GLOB MODULES "${PACKAGE}/*.py")
     
     foreach(MODULE ${MODULES})
         get_filename_component(MODULE_NAME ${MODULE} NAME)
         install(FILES ${MODULE}
-                DESTINATION ${Python3_SITELIB}/${PROJECT_NAME}/${PACKAGE})
+                DESTINATION ${PYTHON_SITELIB}/${PROJECT_NAME}/${PACKAGE})
         
         # add_custom_target(
         #     "${MODULE_NAME}"


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Current CMakeLists.txt when CMake flag `PYTHON_SITELIB` was overwritten did not respact that for python files. 
For example when building with `PYTHON_SITELIB=/usr/local/lib/python3.10/site-packages`, c++ bindings ended up in `/usr/local/lib/python3.10/site-packages` directory, while python files in `/usr/lib/python3/dist-packages`. This unifies it.

## How I Tested

[//]: # "Explain how you tested your changes"

I looked at installation paths.

## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

Nothing to wait for.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
